### PR TITLE
Fix ConceptIdCache loading only 10 concepts instead of all

### DIFF
--- a/src/infrastructure/lancedb/repositories/lancedb-concept-repository.ts
+++ b/src/infrastructure/lancedb/repositories/lancedb-concept-repository.ts
@@ -125,8 +125,11 @@ export class LanceDBConceptRepository implements ConceptRepository {
   async findAll(): Promise<Concept[]> {
     try {
       // Load all concepts from database
+      // LanceDB query() has a default limit of 10 rows (safety feature)
+      // Concepts table can have 10k-100k+ concepts, so we need an explicit high limit
       const results = await this.conceptsTable
         .query()
+        .limit(100000) // High limit to ensure all concepts are loaded (10x safety margin over typical max)
         .toArray();
       
       // Map to Concept domain models and attach IDs


### PR DESCRIPTION
## Problem

The `ConceptIdCache` was only loading 10 concepts instead of all 41,791 concepts in the database. This was caused by `LanceDBConceptRepository.findAll()` not setting an explicit limit, which defaulted to LanceDB's safety limit of 10 rows.

## Solution

Added `.limit(100000)` to the `findAll()` method in `LanceDBConceptRepository`, matching the pattern used in `LanceDBCategoryRepository`. This ensures all concepts are loaded into the cache.

## Impact

- **Before**: Cache only contained 10 concepts, causing lookups to fail for 99.98% of concepts
- **After**: Cache now correctly loads all 41,791 concepts (~11MB memory)
- **Performance**: O(1) in-memory lookups now work for all concepts instead of just 10

## Testing

Verified by running the refresh script which now correctly loads all concepts:
```
✅ Cache refreshed successfully!
   Concepts loaded: 41791
   Memory estimate: ~11427KB
```

## Related

Fixes issue where ConceptIdCache was suspiciously low after adding new books to the database.