### PR TITLE
docs: refine home page layout and add How It Works section

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,5 +1,7 @@
 # Architecture
 
+This section covers the technical architecture of Concept-RAG.
+
 ## Repository Structure
 
 | Directory | Contents |
@@ -12,97 +14,16 @@
 | `src/tools/` | MCP tool implementations (10 tools) |
 | `src/wordnet/` | WordNet integration and strategies |
 | `docs/` | MkDocs documentation site |
-| `docs/architecture/` | 52 Architecture Decision Records |
+| `docs/architecture/` | Architecture Decision Records |
 | `scripts/` | Maintenance and diagnostic utilities |
 | `prompts/` | LLM prompt templates |
 
----
+## Key Components
 
-## Architectural Decision Records (ADRs)
+- **[Seeding Architecture](seeding-architecture.md)** - Document processing pipeline with checkpoint/recovery
+- **[BM25 Keywords](bm25-keywords.md)** - Keyword-based search scoring  
+- **[WordNet Enrichment](wordnet-enrichment.md)** - Semantic query expansion
+- **[Database Schema](../database-schema.md)** - LanceDB table structures
+- **[Stage Cache](../stage-cache-structure.md)** - Intermediate processing cache
 
-This directory contains all architectural decisions made during the development of concept-rag, from its fork from lance-mcp (2024) through December 2025. Each ADR documents the context, alternatives considered, decision made, and consequences.
-
-### ADR Index
-
-| # | Title | Date | Status |
-|---|-------|------|--------|
-| [ADR-0001](adr0001-typescript-nodejs-runtime.md) | TypeScript with Node.js Runtime | ~2024 | Accepted (Inherited) |
-| [ADR-0002](adr0002-lancedb-vector-storage.md) | LanceDB for Vector Storage | ~2024 | Accepted (Inherited) |
-| [ADR-0003](adr0003-mcp-protocol.md) | MCP Protocol for AI Agent Integration | ~2024 | Accepted (Inherited) |
-| [ADR-0004](adr0004-rag-architecture.md) | RAG Architecture Approach | ~2024 | Accepted (Inherited) |
-| [ADR-0005](adr0005-pdf-document-processing.md) | PDF Document Processing | ~2024 | Accepted (Inherited) |
-| [ADR-0006](adr0006-hybrid-search-strategy.md) | Hybrid Search Strategy (Multi-Signal Ranking) | 2025-10-13 | Accepted |
-| [ADR-0007](adr0007-concept-extraction-llm.md) | Concept Extraction with LLM (Claude Sonnet 4.5) | 2025-10-13 | Accepted |
-| [ADR-0008](adr0008-wordnet-integration.md) | WordNet Integration for Semantic Enrichment | 2025-10-13 | Accepted |
-| [ADR-0009](adr0009-three-table-architecture.md) | Three-Table Architecture (Catalog, Chunks, Concepts) | 2025-10-13 | Accepted |
-| [ADR-0010](adr0010-query-expansion.md) | Query Expansion Strategy (Corpus + WordNet) | 2025-10-13 | Accepted |
-| [ADR-0011](adr0011-multi-model-strategy.md) | Multi-Model Strategy (Claude + Grok) | 2025-10-13 | Accepted |
-| [ADR-0012](adr0012-ocr-fallback-tesseract.md) | OCR Fallback with Tesseract | 2025-10-21 | Accepted |
-| [ADR-0013](adr0013-incremental-seeding.md) | Incremental Seeding Strategy | 2025-11-12 | Accepted |
-| [ADR-0014](adr0014-multi-pass-extraction.md) | Multi-Pass Extraction for Large Documents | 2025-11-12 | Accepted |
-| [ADR-0015](adr0015-formal-concept-model.md) | Formal Concept Model Definition | 2025-11-13 | Accepted |
-| [ADR-0016](adr0016-layered-architecture-refactoring.md) | Layered Architecture Refactoring | 2025-11-14 | Accepted |
-| [ADR-0017](adr0017-repository-pattern.md) | Repository Pattern for Data Access | 2025-11-14 | Accepted |
-| [ADR-0018](adr0018-dependency-injection-container.md) | Dependency Injection Container | 2025-11-14 | Accepted |
-| [ADR-0019](adr0019-vitest-testing-framework.md) | Vitest as Testing Framework | 2025-11-14 | Accepted |
-| [ADR-0020](adr0020-typescript-strict-mode.md) | TypeScript Strict Mode Enablement | 2025-11-14 | Accepted |
-| [ADR-0021](adr0021-performance-optimization-vector-search.md) | Performance Optimization (O(n) to O(log n)) | 2025-11-14 | Accepted |
-| [ADR-0022](adr0022-hybrid-search-service-extraction.md) | HybridSearchService Extraction | 2025-11-14 | Accepted |
-| [ADR-0023](adr0023-sql-injection-prevention.md) | SQL Injection Prevention | 2025-11-14 | Accepted |
-| [ADR-0024](adr0024-multi-provider-embeddings.md) | Multi-Provider Embedding Architecture | 2025-11-15 | Accepted |
-| [ADR-0025](adr0025-document-loader-factory.md) | Document Loader Factory Pattern | 2025-11-15 | Accepted |
-| [ADR-0026](adr0026-epub-format-support.md) | EPUB Format Support | 2025-11-15 | Accepted |
-| [ADR-0027](adr0027-hash-based-integer-ids.md) | Hash-Based Integer IDs (FNV-1a) | 2025-11-19 | Accepted |
-| [ADR-0028](adr0028-category-storage-strategy.md) | Category Storage Strategy | 2025-11-19 | Accepted |
-| [ADR-0029](adr0029-category-search-tools.md) | Category Search Tools | 2025-11-19 | Accepted |
-| [ADR-0030](adr0030-auto-extracted-categories.md) | 46 Auto-Extracted Categories | 2025-11-19 | Accepted |
-| [ADR-0031](adr0031-eight-specialized-tools-strategy.md) | Eight Specialized Tools Strategy | 2025-11-19 | Accepted |
-| [ADR-0032](adr0032-tool-selection-guide.md) | Tool Selection Guide for AI Agents | 2025-11-13 | Accepted |
-| [ADR-0033](adr0033-basetool-abstraction.md) | BaseTool Abstraction Pattern | ~2024-2025 | Accepted |
-| [ADR-0034](adr0034-comprehensive-error-handling.md) | Comprehensive Error Handling Infrastructure | 2025-11-22 | Accepted |
-| [ADR-0035](adr0035-test-suite-expansion.md) | Test Suite Expansion (120 → 534 tests) | 2025-11-22 | Accepted |
-| [ADR-0036](adr0036-configuration-centralization.md) | Configuration Centralization with Type Safety | 2025-11-22 | Accepted |
-| [ADR-0037](adr0037-functional-validation-layer.md) | Functional Validation Layer Pattern | 2025-11-22 | Accepted |
-| [ADR-0038](adr0038-dependency-rules-enforcement.md) | Architecture Dependency Rules Enforcement | 2025-11-22 | Accepted |
-| [ADR-0039](adr0039-observability-infrastructure.md) | Observability Infrastructure | 2025-11-23 | Accepted |
-| [ADR-0040](adr0040-result-option-types.md) | Result/Option Types for Functional Error Handling | 2025-11-23 | Accepted |
-| [ADR-0041](adr0041-advanced-caching.md) | Multi-Level Caching Strategy (LRU + TTL) | 2025-11-24 | Accepted |
-| [ADR-0042](adr0042-system-resilience-patterns.md) | System Resilience Patterns | 2025-11-25 | Accepted |
-| [ADR-0043](adr0043-schema-normalization.md) | Schema Normalization | 2025-11-26 | Accepted |
-| [ADR-0044](adr0044-seeding-script-modularization.md) | Seeding Script Modularization | 2025-12-03 | Accepted |
-| [ADR-0045](adr0045-api-key-preflight-check.md) | API Key Preflight Check | 2025-12-05 | Accepted |
-| [ADR-0046](adr0046-document-type-classification.md) | Document Type Classification | 2025-12-07 | Accepted |
-| [ADR-0047](adr0047-architecture-review-dec-2025.md) | Architecture Review December 2025 | 2025-12-08 | Accepted |
-| [ADR-0048](adr0048-stage-caching.md) | Stage Caching | 2025-12-10 | Accepted |
-| [ADR-0049](adr0049-incremental-category-summaries.md) | Incremental Category Summaries | 2025-12-12 | Accepted |
-| [ADR-0050](adr0050-mkdocs-material-documentation-site.md) | MkDocs Material Documentation Site | 2025-12-14 | Accepted |
-| [ADR-0051](adr0051-api-documentation-consolidation.md) | API Documentation Separation of Concerns | 2025-12-14 | Accepted |
-| [ADR-0052](adr0052-documentation-site-restructure.md) | Documentation Site Restructure | 2025-12-25 | Accepted |
-
----
-
-### Using This Documentation
-
-#### For Adding New ADRs
-
-1. **Use the template:** Copy an existing ADR as a starting point
-2. **Determine number:** Next sequential number (adr0053, adr0054, etc.)
-3. **Include citations:** Every fact needs source reference
-4. **Add to this index:** Update README.md with new ADR
-5. **Cross-reference:** Link to related ADRs
-
-#### For Updating ADRs
-
-**ADRs are immutable** once accepted. To change a decision:
-
-1. Create new ADR with new decision
-2. Update old ADR status to "Superseded by ADR-XXXX"
-3. Link between old and new ADRs
-
-#### For Deprecating ADRs
-
-If decision is reversed without replacement:
-
-1. Change status to "Deprecated"
-2. Add deprecation note explaining why
-3. Keep content intact (historical record)
+For architectural decisions and their rationale, see the **[ADRs](../architecture/adr0001-typescript-nodejs-runtime.md)** section.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,111 @@
+# How It Works
+
+Concept-RAG processes your documents through a multi-stage pipeline that extracts meaning, generates embeddings, and enables powerful hybrid search.
+
+```mermaid
+flowchart TB
+    subgraph Input["📄 Documents"]
+        PDF[PDF Files]
+        EPUB[EPUB Files]
+    end
+
+    subgraph Processing["⚙️ Processing Pipeline"]
+        Parse[Parse & Extract Text]
+        OCR[OCR Fallback]
+        Chunk[Chunk Text]
+        Extract[Extract Concepts]
+        Embed[Generate Embeddings]
+        Summarize[Generate Summary]
+    end
+
+    subgraph Storage["💾 LanceDB Storage"]
+        Catalog[(Catalog<br/>Documents)]
+        Chunks[(Chunks<br/>Text Segments)]
+        Concepts[(Concepts<br/>Index)]
+        Categories[(Categories<br/>Taxonomy)]
+    end
+
+    subgraph Search["🔍 Hybrid Search"]
+        Vector[Vector Similarity]
+        BM25[BM25 Keywords]
+        ConceptMatch[Concept Matching]
+        WordNet[WordNet Expansion]
+        Rank[Weighted Ranking]
+    end
+
+    subgraph Output["🤖 MCP Tools"]
+        Tools[10 Specialized Tools]
+        AI[AI Assistants]
+    end
+
+    PDF --> Parse
+    EPUB --> Parse
+    Parse --> OCR
+    OCR --> Chunk
+    Chunk --> Extract
+    Chunk --> Embed
+    Extract --> Summarize
+
+    Embed --> Chunks
+    Extract --> Concepts
+    Summarize --> Catalog
+    Extract --> Categories
+
+    Catalog --> Vector
+    Chunks --> Vector
+    Concepts --> ConceptMatch
+    
+    Vector --> Rank
+    BM25 --> Rank
+    ConceptMatch --> Rank
+    WordNet --> Rank
+    
+    Rank --> Tools
+    Tools --> AI
+```
+
+## Pipeline Stages
+
+### 1. Document Ingestion
+
+- **PDF Processing**: Text extraction with layout preservation
+- **EPUB Processing**: Structured content extraction from chapters
+- **OCR Fallback**: Tesseract for scanned documents with no extractable text
+
+### 2. Text Chunking
+
+Documents are split into semantic chunks optimized for retrieval:
+
+- Target size: ~500 tokens per chunk
+- Overlap between chunks to preserve context
+- Page number tracking for citations
+
+### 3. Concept Extraction
+
+Each document is analyzed by an LLM to extract:
+
+- **Primary Concepts**: Core topics and themes (15-25 per document)
+- **Technical Terms**: Domain-specific vocabulary
+- **Related Concepts**: Secondary ideas and connections
+
+### 4. Embedding Generation
+
+Vector embeddings are generated for:
+
+- Document summaries (catalog search)
+- Individual chunks (content search)
+- Concept definitions (semantic matching)
+
+### 5. Hybrid Search
+
+Queries are scored using four signals:
+
+| Signal | Weight | Purpose |
+|--------|--------|---------|
+| Vector Similarity | 35% | Semantic meaning match |
+| BM25 Keywords | 35% | Exact term matching |
+| Concept Matching | 15% | Extracted concept overlap |
+| WordNet Expansion | 15% | Synonym and hypernym matching |
+
+Results are combined using weighted ranking for optimal retrieval accuracy.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,134 +6,70 @@ Concept-RAG is an MCP server that enables AI assistants to interact with your PD
 
 <div class="grid cards" markdown>
 
--   :material-brain:{ .lg .middle } **Conceptual Search**
+-   :material-cog-play:{ .lg .middle } **How It Works**
 
     ---
 
-    Search by meaning with 80-150+ extracted concepts per document
+    Document processing pipeline and hybrid search architecture
 
-    [:octicons-arrow-right-24: How it works](#how-it-works)
+    [:octicons-arrow-right-24: Learn more](how-it-works.md)
 
--   :material-magnify:{ .lg .middle } **Hybrid Ranking**
-
-    ---
-
-    4-signal scoring: Vector + BM25 + Concepts + WordNet
-
-    [:octicons-arrow-right-24: Architecture](architecture/README.md)
-
--   :material-book-multiple:{ .lg .middle } **Multi-Format**
+-   :material-rocket-launch:{ .lg .middle } **Getting Started**
 
     ---
-
-    PDF and EPUB with OCR fallback for scanned documents
-
-    [:octicons-arrow-right-24: Getting Started](getting-started.md)
-
--   :material-lightning-bolt:{ .lg .middle } **High Performance**
-
-    ---
-
-    80x-240x faster searches with optimized indexing
-
-    [:octicons-arrow-right-24: API Reference](api-reference.md)
-
-</div>
-
----
-
-## How It Works
-
-```mermaid
-flowchart TB
-    subgraph Input["📄 Documents"]
-        PDF[PDF Files]
-        EPUB[EPUB Files]
-    end
-
-    subgraph Processing["⚙️ Processing Pipeline"]
-        Parse[Parse & Extract Text]
-        OCR[OCR Fallback]
-        Chunk[Chunk Text]
-        Extract[Extract Concepts<br/>Claude Sonnet]
-        Embed[Generate Embeddings]
-        Summarize[Generate Summary<br/>Grok-4-fast]
-    end
-
-    subgraph Storage["💾 LanceDB Storage"]
-        Catalog[(Catalog<br/>Documents)]
-        Chunks[(Chunks<br/>Text Segments)]
-        Concepts[(Concepts<br/>Index)]
-        Categories[(Categories<br/>Taxonomy)]
-    end
-
-    subgraph Search["🔍 Hybrid Search"]
-        Vector[Vector Similarity]
-        BM25[BM25 Keywords]
-        ConceptMatch[Concept Matching]
-        WordNet[WordNet Expansion]
-        Rank[Weighted Ranking]
-    end
-
-    subgraph Output["🤖 MCP Tools"]
-        Tools[10 Specialized Tools]
-        AI[AI Assistants]
-    end
-
-    PDF --> Parse
-    EPUB --> Parse
-    Parse --> OCR
-    OCR --> Chunk
-    Chunk --> Extract
-    Chunk --> Embed
-    Extract --> Summarize
-
-    Embed --> Chunks
-    Extract --> Concepts
-    Summarize --> Catalog
-    Extract --> Categories
-
-    Catalog --> Vector
-    Chunks --> Vector
-    Concepts --> ConceptMatch
-    
-    Vector --> Rank
-    BM25 --> Rank
-    ConceptMatch --> Rank
-    WordNet --> Rank
-    
-    Rank --> Tools
-    Tools --> AI
-```
-
----
-
-## Quick Links
-
-<div class="grid cards" markdown>
-
--   [:material-rocket-launch: **Getting Started**](getting-started.md)
 
     Install and configure in under 10 minutes
 
--   [:material-compass: **Tool Selection Guide**](tool-selection-guide.md)
+    [:octicons-arrow-right-24: Quick start](getting-started.md)
 
-    Choose the right tool for your query
+-   :material-compass:{ .lg .middle } **Tool Selection**
 
--   [:material-api: **API Reference**](api-reference.md)
+    ---
 
-    Complete MCP tool documentation
+    Choose the right MCP tool for your query type
 
--   [:material-help-circle: **FAQ**](faq.md)
+    [:octicons-arrow-right-24: Selection guide](tool-selection-guide.md)
+
+-   :material-api:{ .lg .middle } **API Reference**
+
+    ---
+
+    Complete documentation for all 10 MCP tools
+
+    [:octicons-arrow-right-24: View API](api-reference.md)
+
+-   :material-sitemap:{ .lg .middle } **Architecture**
+
+    ---
+
+    Technical deep-dive into system design and components
+
+    [:octicons-arrow-right-24: Explore](architecture/README.md)
+
+-   :material-help-circle:{ .lg .middle } **FAQ**
+
+    ---
 
     Common questions answered
 
--   [:material-wrench: **Troubleshooting**](troubleshooting.md)
+    [:octicons-arrow-right-24: Read FAQ](faq.md)
 
-    Fix common issues
+-   :material-wrench:{ .lg .middle } **Troubleshooting**
 
--   [:material-github: **GitHub**](https://github.com/m2ux/concept-rag)
+    ---
+
+    Fix common issues quickly
+
+    [:octicons-arrow-right-24: Get help](troubleshooting.md)
+
+-   :material-github:{ .lg .middle } **GitHub**
+
+    ---
 
     Source code and contributions
 
+    [:octicons-arrow-right-24: Repository](https://github.com/m2ux/concept-rag)
+
 </div>
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,8 @@ markdown_extensions:
 nav:
   - Home: index.md
 
+  - How It Works: how-it-works.md
+
   - Getting Started:
     - Quick Start: getting-started.md
     - Troubleshooting: troubleshooting.md


### PR DESCRIPTION
## Summary

Refines the documentation site home page and adds a dedicated 'How It Works' section.

## Changes

### New Page
- **How It Works** (`docs/how-it-works.md`): Dedicated page with the processing pipeline diagram and detailed explanations of each stage

### Home Page Improvements
- Merged two separate card grids into a single unified 8-tile layout
- Updated tile titles to match their destination pages:
  - How It Works, Getting Started, Tool Selection, API Reference
  - Architecture, FAQ, Troubleshooting, GitHub
- Consistent formatting with icons, descriptions, and arrow links

### Architecture Section
- Removed ADR index from Architecture overview (ADRs have their own dedicated section)
- Focused content on repository structure and key component links

### Navigation
- Added 'How It Works' as top-level nav item after 'Home'

## Testing
- Verified with `mkdocs serve` local preview
- All internal links validated