### PR TITLE
refactor: gate score components behind debugSearch config

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -34,14 +34,7 @@ Search document summaries and metadata to discover relevant documents.
   {
     "source": "string",
     "summary": "string",
-    "scores": {
-      "hybrid": "string",
-      "vector": "string",
-      "bm25": "string",
-      "title": "string",
-      "concept": "string",
-      "wordnet": "string"
-    },
+    "score": "string",
     "expanded_terms": ["string"]
   }
 ]
@@ -51,15 +44,22 @@ Search document summaries and metadata to discover relevant documents.
 |-------|------|-------------|
 | `source` | string | Full file path to document |
 | `summary` | string | Document summary text |
-| `scores.hybrid` | string | Combined weighted score |
-| `scores.vector` | string | Semantic similarity (0-1) |
-| `scores.bm25` | string | Keyword relevance (0-1) |
-| `scores.title` | string | Title match (0-1) |
-| `scores.concept` | string | Concept alignment (0-1) |
-| `scores.wordnet` | string | Synonym expansion (0-1) |
+| `score` | string | Combined hybrid score (0.000-1.000) |
 | `expanded_terms` | string[] | Expanded query terms |
 
 **Limits:** 10 documents max.
+
+#### Additional Fields with Debug Enabled
+
+When `DEBUG_SEARCH=true`, each result includes score component breakdown:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `score_components.vector` | string | Semantic similarity (0-1) |
+| `score_components.bm25` | string | Keyword relevance (0-1) |
+| `score_components.title` | string | Title match (0-1) |
+| `score_components.concept` | string | Concept alignment (0-1) |
+| `score_components.wordnet` | string | Synonym expansion (0-1) |
 
 ---
 
@@ -90,13 +90,7 @@ Search across all document chunks using hybrid search.
   {
     "text": "string",
     "source": "string",
-    "scores": {
-      "hybrid": "string",
-      "vector": "string",
-      "bm25": "string",
-      "concept": "string",
-      "wordnet": "string"
-    },
+    "score": "string",
     "expanded_terms": ["string"]
   }
 ]
@@ -106,14 +100,21 @@ Search across all document chunks using hybrid search.
 |-------|------|-------------|
 | `text` | string | Chunk content |
 | `source` | string | Source document path |
-| `scores.hybrid` | string | Combined score |
-| `scores.vector` | string | Semantic similarity |
-| `scores.bm25` | string | Keyword relevance |
-| `scores.concept` | string | Concept alignment |
-| `scores.wordnet` | string | Synonym expansion |
+| `score` | string | Combined hybrid score (0.000-1.000) |
 | `expanded_terms` | string[] | Expanded query terms |
 
 **Limits:** 20 chunks max.
+
+#### Additional Fields with Debug Enabled
+
+When `DEBUG_SEARCH=true`, each result includes score component breakdown:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `score_components.vector` | string | Semantic similarity (0-1) |
+| `score_components.bm25` | string | Keyword relevance (0-1) |
+| `score_components.concept` | string | Concept alignment (0-1) |
+| `score_components.wordnet` | string | Synonym expansion (0-1) |
 
 ---
 
@@ -221,13 +222,7 @@ Find chunks associated with a concept, organized hierarchically.
     "sources_returned": 0,
     "chunks_returned": 0
   },
-  "scores": {
-    "hybrid": "string",
-    "name": "string",
-    "vector": "string",
-    "bm25": "string",
-    "wordnet": "string"
-  }
+  "score": "string"
 }
 ```
 
@@ -248,15 +243,26 @@ Find chunks associated with a concept, organized hierarchically.
 | `chunks[].page` | number | Page number |
 | `chunks[].concept_density` | string | Prominence (0.000-1.000) |
 | `stats` | object | Search statistics |
-| `scores` | object | Hybrid search scores |
+| `score` | string | Combined hybrid score (0.000-1.000) |
 
 #### Additional Fields with Debug Enabled
 
-When `DEBUG_SEARCH=true` environment variable is set, each source includes `page_previews`:
+When `DEBUG_SEARCH=true` environment variable is set:
+
+**Sources include page previews:**
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `sources[].page_previews` | string[] | Text previews from each page |
+
+**Score component breakdown is included:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `score_components.name` | string | Concept name match (0-1) |
+| `score_components.vector` | string | Semantic similarity (0-1) |
+| `score_components.bm25` | string | Keyword relevance (0-1) |
+| `score_components.wordnet` | string | Synonym expansion (0-1) |
 
 ---
 

--- a/src/tools/operations/__tests__/conceptual-broad-chunks-search.test.ts
+++ b/src/tools/operations/__tests__/conceptual-broad-chunks-search.test.ts
@@ -56,7 +56,7 @@ describe('ConceptualBroadChunksSearchTool', () => {
       expect(Array.isArray(parsedContent)).toBe(true);
       expect(parsedContent).toHaveLength(2);
       expect(parsedContent[0].source).toBe('/test/doc1.pdf');
-      expect(parsedContent[0].scores).toBeDefined();
+      expect(parsedContent[0].score).toBeDefined();  // Hybrid score always shown
     });
     
     it('should respect limit parameter (defaults to 10)', async () => {
@@ -95,11 +95,10 @@ describe('ConceptualBroadChunksSearchTool', () => {
       // EXERCISE
       const result = await tool.execute({ text: 'test' });
       
-      // VERIFY
+      // VERIFY - hybrid score always shown as 'score', components only in debug
       const parsedContent = JSON.parse(result.content[0].text);
-      expect(parsedContent[0].scores.hybrid).toBe('0.950');
-      expect(parsedContent[0].scores.vector).toBe('0.850');
-      expect(parsedContent[0].scores.bm25).toBe('0.750');
+      expect(parsedContent[0].score).toBe('0.950');
+      expect(parsedContent[0].score_components).toBeUndefined();  // Not in debug mode
     });
     
     it('should include expanded terms when debug is enabled', async () => {

--- a/src/tools/operations/__tests__/conceptual-catalog-search.test.ts
+++ b/src/tools/operations/__tests__/conceptual-catalog-search.test.ts
@@ -57,8 +57,7 @@ describe('ConceptualCatalogSearchTool', () => {
       expect(Array.isArray(parsedContent)).toBe(true);
       expect(parsedContent.length).toBeGreaterThan(0);
       expect(parsedContent[0].source).toBeDefined();
-      expect(parsedContent[0].scores).toBeDefined();
-      expect(parsedContent[0].scores.hybrid).toBeDefined();
+      expect(parsedContent[0].score).toBeDefined();  // Hybrid score always shown
     });
     
     it('should respect limit parameter (defaults to 10)', async () => {
@@ -111,7 +110,7 @@ describe('ConceptualCatalogSearchTool', () => {
       expect(parsedContent).toEqual([]);
     });
     
-    it('should format scores correctly', async () => {
+    it('should format score correctly', async () => {
       // SETUP
       const testResults = [
         createTestSearchResult({
@@ -127,11 +126,10 @@ describe('ConceptualCatalogSearchTool', () => {
       // EXERCISE
       const result = await tool.execute({ text: 'test' });
       
-      // VERIFY
+      // VERIFY - hybrid score always shown as 'score', components only in debug
       const parsedContent = JSON.parse(result.content[0].text);
-      expect(parsedContent[0].scores.hybrid).toBe('0.123');
-      expect(parsedContent[0].scores.vector).toBe('0.789');
-      expect(parsedContent[0].scores.bm25).toBe('0.346');
+      expect(parsedContent[0].score).toBe('0.123');
+      expect(parsedContent[0].score_components).toBeUndefined();  // Not in debug mode
     });
     
     it('should handle errors gracefully', async () => {

--- a/src/tools/operations/concept_search.ts
+++ b/src/tools/operations/concept_search.ts
@@ -191,10 +191,12 @@ Debug output can be enabled via DEBUG_SEARCH=true environment variable.`;
         chunks_returned: result.chunks.length
       },
       
-      // Detailed hybrid search scores (always shown for debugging)
-      ...(result.scores ? {
-        scores: {
-          hybrid: result.scores.hybridScore.toFixed(3),
+      // Hybrid score always shown
+      ...(result.scores ? { score: result.scores.hybridScore.toFixed(3) } : {}),
+      
+      // Component breakdown only when debug enabled
+      ...(debug && result.scores ? {
+        score_components: {
           name: result.scores.nameScore.toFixed(3),
           vector: result.scores.vectorScore.toFixed(3),
           bm25: result.scores.bm25Score.toFixed(3),

--- a/src/tools/operations/conceptual_broad_chunks_search.ts
+++ b/src/tools/operations/conceptual_broad_chunks_search.ts
@@ -116,13 +116,15 @@ Debug output can be enabled via DEBUG_SEARCH=true environment variable.`;
       .map((r: SearchResult) => ({
         text: r.text,
         source: r.source,
-        scores: {
-          hybrid: r.hybridScore.toFixed(3),
-          vector: r.vectorScore.toFixed(3),
-          bm25: r.bm25Score.toFixed(3),
-          concept: r.conceptScore.toFixed(3),
-          wordnet: r.wordnetScore.toFixed(3)
-        },
+        score: r.hybridScore.toFixed(3),  // Hybrid score always shown
+        ...(debugSearch && {
+          score_components: {  // Component breakdown only in debug mode
+            vector: r.vectorScore.toFixed(3),
+            bm25: r.bm25Score.toFixed(3),
+            concept: r.conceptScore.toFixed(3),
+            wordnet: r.wordnetScore.toFixed(3)
+          }
+        }),
         expanded_terms: r.expandedTerms
       }));
     

--- a/src/tools/operations/conceptual_catalog_search.ts
+++ b/src/tools/operations/conceptual_catalog_search.ts
@@ -113,14 +113,16 @@ Debug output can be enabled via DEBUG_SEARCH=true environment variable.`;
       .map((r: SearchResult) => ({
         source: r.source,
         summary: r.text,  // Full summary (not truncated)
-        scores: {
-          hybrid: r.hybridScore.toFixed(3),
-          vector: r.vectorScore.toFixed(3),
-          bm25: r.bm25Score.toFixed(3),
-          title: r.titleScore.toFixed(3),
-          concept: r.conceptScore.toFixed(3),
-          wordnet: r.wordnetScore.toFixed(3)
-        },
+        score: r.hybridScore.toFixed(3),  // Hybrid score always shown
+        ...(debugSearch && {
+          score_components: {  // Component breakdown only in debug mode
+            vector: r.vectorScore.toFixed(3),
+            bm25: r.bm25Score.toFixed(3),
+            title: r.titleScore.toFixed(3),
+            concept: r.conceptScore.toFixed(3),
+            wordnet: r.wordnetScore.toFixed(3)
+          }
+        }),
         expanded_terms: r.expandedTerms
       }));
     


### PR DESCRIPTION
## Summary

Gate score component breakdown behind `DEBUG_SEARCH=true` configuration. The hybrid score remains visible as a `score` field, while the detailed component breakdown (`vector`, `bm25`, `title`, `concept`, `wordnet`) is only included when debug mode is enabled.

## Issue

🎫 [Issue #59](https://github.com/m2ux/concept-rag/issues/59) - Gate scoring output behind debug flag in MCP tools

## Motivation

- **Reduced output size**: ~150-200 bytes per result saved in normal operation
- **Cleaner LLM context**: Agents see only the essential hybrid score
- **Debug capability preserved**: Full score breakdown available via `DEBUG_SEARCH=true`
- **Consistency**: Aligns with PR #58 which deprecated the `debug` input parameter

## Changes

### Tool Output Schema Changes

**Before:**
```json
{
  "source": "/path/to/doc.pdf",
  "summary": "...",
  "scores": {
    "hybrid": "0.750",
    "vector": "0.680",
    "bm25": "0.520",
    "title": "0.900",
    "concept": "0.450",
    "wordnet": "0.230"
  },
  "expanded_terms": [...]
}
```

**After (normal mode):**
```json
{
  "source": "/path/to/doc.pdf",
  "summary": "...",
  "score": "0.750",
  "expanded_terms": [...]
}
```

**After (with DEBUG_SEARCH=true):**
```json
{
  "source": "/path/to/doc.pdf",
  "summary": "...",
  "score": "0.750",
  "score_components": {
    "vector": "0.680",
    "bm25": "0.520",
    "title": "0.900",
    "concept": "0.450",
    "wordnet": "0.230"
  },
  "expanded_terms": [...]
}
```

### Files Modified

- `src/tools/operations/conceptual_catalog_search.ts` - Gate score_components
- `src/tools/operations/conceptual_broad_chunks_search.ts` - Gate score_components
- `src/tools/operations/concept_search.ts` - Gate score_components
- `docs/api-reference.md` - Update output schemas
- Test files updated to match new schema

## Checklists

### Submission
- [x] Implementation complete
- [x] Tests updated and passing
- [x] Documentation updated

### TODO before merging
- [ ] PR marked ready for review