### PR TITLE
fix(mcp): resolve guidance file paths relative to module

### DIFF
--- a/src/conceptual_index.ts
+++ b/src/conceptual_index.ts
@@ -11,6 +11,11 @@ import { ApplicationContainer } from "./application/container.js";
 import * as defaults from './config.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '../');
 
 /**
  * MCP Resources Configuration
@@ -81,7 +86,7 @@ async function main() {
     const availableResources = RESOURCES.filter(resource => {
       try {
         // Resolve path relative to package root
-        const fullPath = path.resolve(process.cwd(), resource.filePath);
+        const fullPath = path.resolve(PROJECT_ROOT, resource.filePath);
         return fs.existsSync(fullPath);
       } catch {
         return false;
@@ -108,7 +113,7 @@ async function main() {
     }
 
     // Read the file
-    const fullPath = path.resolve(process.cwd(), resource.filePath);
+    const fullPath = path.resolve(PROJECT_ROOT, resource.filePath);
     if (!fs.existsSync(fullPath)) {
       throw new Error(`Resource file not found: ${resource.filePath}`);
     }

--- a/src/tools/operations/get-guidance-tool.ts
+++ b/src/tools/operations/get-guidance-tool.ts
@@ -8,6 +8,11 @@
 import { BaseTool, ToolParams } from '../base/tool.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '../../../');
 
 export interface GetGuidanceParams extends ToolParams {
   topic?: 'rules' | 'tool-selection' | 'all';
@@ -50,7 +55,7 @@ RECOMMENDED: Call with topic='rules' at the start of each session to ensure high
     
     try {
       if (topic === 'rules' || topic === 'all') {
-        const rulesPath = path.resolve(process.cwd(), 'prompts/get-guidance.md');
+        const rulesPath = path.resolve(PROJECT_ROOT, 'prompts/get-guidance.md');
         if (fs.existsSync(rulesPath)) {
           const rules = fs.readFileSync(rulesPath, 'utf-8');
           results.push('# Agent Research Rules\n\n' + rules);
@@ -60,7 +65,7 @@ RECOMMENDED: Call with topic='rules' at the start of each session to ensure high
       }
       
       if (topic === 'tool-selection' || topic === 'all') {
-        const guidePath = path.resolve(process.cwd(), 'docs/tool-selection-guide.md');
+        const guidePath = path.resolve(PROJECT_ROOT, 'docs/tool-selection-guide.md');
         if (fs.existsSync(guidePath)) {
           const guide = fs.readFileSync(guidePath, 'utf-8');
           results.push('# Tool Selection Guide\n\n' + guide);


### PR DESCRIPTION
## Summary

Fixes "File not found" errors for `prompts/get-guidance.md` and `docs/tool-selection-guide.md` when the MCP server is invoked from a working directory other than the project root.

## Problem

The `get_guidance` tool and MCP resource handlers used `process.cwd()` to resolve file paths:

```typescript
const rulesPath = path.resolve(process.cwd(), 'prompts/get-guidance.md');
```

When Cursor (or other MCP clients) invokes the server, `process.cwd()` is the client's working directory, not the concept-rag project root. This caused the guidance files to not be found.

## Solution

Use `import.meta.url` to resolve paths relative to the module location:

```typescript
import { fileURLToPath } from 'url';

const __filename = fileURLToPath(import.meta.url);
const __dirname = path.dirname(__filename);
const PROJECT_ROOT = path.resolve(__dirname, '../');  // or '../../../' for nested modules

const rulesPath = path.resolve(PROJECT_ROOT, 'prompts/get-guidance.md');
```

This follows the existing pattern used elsewhere in the codebase (e.g., `src/config.ts`, `src/infrastructure/visual-extraction/local-classifier.ts`).

## Files Changed

- `src/tools/operations/get-guidance-tool.ts` - Use `PROJECT_ROOT` for guidance file paths
- `src/conceptual_index.ts` - Use `PROJECT_ROOT` for MCP resource file paths

## Testing

- Build verified: `npm run build` succeeds
- Manual verification: Restart MCP server and call `get_guidance` tool