### PR TITLE
chore: set package version to 2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "concept-rag",
-  "version": "1.0.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "concept-rag",
-      "version": "1.0.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "@lancedb/lancedb": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concept-rag",
-  "version": "1.0.0",
+  "version": "2.5.1",
   "author": {
     "name": "Alex Komyagin",
     "email": "alex@adiom.io"


### PR DESCRIPTION
## Sync manifest version to 2.5.1

The `package.json` version had been left at `1.0.0`, decoupled from the git tag scheme (tags are at `v2.5.1`). This brings the manifest — and the `package-lock.json` root entries — in line with the latest release tag, so the manifest tracks releases going forward.

- `package.json`: `1.0.0` → `2.5.1`
- `package-lock.json`: root `version` entries (top-level + `packages[""]`) updated to match; dependency versions untouched.

> Note: the `v2.5.1` tag was already pushed at the PR #74 merge commit, so this bump lands one commit after it. The manifest and tag for *this* release are one commit apart; every release from here on will be in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
